### PR TITLE
Remove additional aider commands input option

### DIFF
--- a/agent_session.py
+++ b/agent_session.py
@@ -26,7 +26,7 @@ def normalize_path(path_str):
         return None
 
 class AgentSession:
-    def __init__(self, workspace_path, task, config=None, aider_commands=None):
+    def __init__(self, workspace_path, task, config=None):
         self.workspace_path = normalize_path(workspace_path)
         self.task = task
         self.output_buffer = io.StringIO()
@@ -34,7 +34,6 @@ class AgentSession:
         self._stop_event = threading.Event()
         self.session_id = str(uuid.uuid4())[:8]  # For logging
         self._buffer_lock = threading.Lock()  # Add lock for thread-safe buffer access
-        self.aider_commands = aider_commands
         
         # Load configuration with defaults
         default_config = {
@@ -74,9 +73,6 @@ class AgentSession:
                 '--no-pretty'
             ]
             
-            # Add custom commands if provided
-            if self.aider_commands:
-                cmd.extend(self.aider_commands.split())
             logging.info(f"[Session {self.session_id}] Executing command: {' '.join(cmd)}")
             
             self.process = subprocess.Popen(


### PR DESCRIPTION
This PR removes the `aider_commands` parameter and related logic from `agent_session.py`. This simplifies the code and makes it more maintainable. The aider CLI tool will now function without the need for additional command-line input options.