### PR TITLE
Add batch script for demonstrating command timeouts

### DIFF
--- a/timeout_demo.bat
+++ b/timeout_demo.bat
@@ -1,0 +1,23 @@
+@echo off
+echo Starting long-running process...
+
+set "long_running_command=ping -n 61 127.0.0.1 >nul"  
+set timeout_seconds=30
+
+echo Starting command: %long_running_command%
+start "" cmd /c "%long_running_command%"
+
+timeout /t %timeout_seconds% /nobreak >nul
+
+echo Checking if command finished...
+
+tasklist /FI "IMAGENAME eq cmd.exe" 2>NUL | find /I /N "cmd.exe">NUL
+if "%ERRORLEVEL%"=="0" (
+  echo Command still running after %timeout_seconds% seconds. Terminating...
+  taskkill /F /IM cmd.exe /T >nul
+  echo Command terminated.
+) else (
+  echo Command finished within the timeout period.
+)
+
+echo Script finished.


### PR DESCRIPTION
This pull request adds a batch script, `timeout_demo.bat`, that demonstrates how to set and manage timeouts for commands in a cmd.exe environment.  The script uses the `timeout` command to set a time limit and `taskkill` to terminate long-running processes if they exceed the timeout.  A long-running command is included for testing purposes.