### PR TITLE
feat: Load LLM model and prompt from config file

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,0 +1,4 @@
+{
+  "llm_model": "YOUR_LLM_MODEL_STRING",
+  "prompt": "YOUR_PROMPT_HERE"
+}


### PR DESCRIPTION
This commit introduces a configuration file (config.json) to manage the LLM model and prompt.  The agent_session.py file is updated to load these settings from the config file, handling potential exceptions during file reading and JSON parsing.  This change improves maintainability and allows for easier experimentation with different models and prompts.  A try-except block is used to catch and log any errors that occur during configuration loading.