### PR TITLE
Update h1 styling to span full viewport width

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -433,3 +433,10 @@ body {
 .cli-output .user-message {
     color: #007bff; /* OKBLUE */
 }
+
+/* h1 selector styles */
+h1 {
+    width: 100%;
+    margin: 0;
+    padding: 0;
+}


### PR DESCRIPTION
Added a new h1 selector to styles.css with the following properties: width: 100%, margin: 0, and padding: 0. This ensures that the h1 element takes up the full width of the viewport without any spacing issues.