### PR TITLE
feat: Add agent action history to AgentSession

### DIFF
--- a/agent_session.py
+++ b/agent_session.py
@@ -35,6 +35,7 @@ class AgentSession:
             'output_buffer_max_length': 10000
         }
         self.config = {**default_config, **(config or {})}
+        self.action_history = []
 
     def start(self) -> bool:
         try:
@@ -177,6 +178,7 @@ class AgentSession:
                 else:
                     return False
             sanitized_message = message.replace('"', '\\"')
+            self.log_action("send_message", {"message": sanitized_message})
             self.process.stdin.write(sanitized_message + "\n")
             self.process.stdin.flush()
             return True
@@ -184,6 +186,13 @@ class AgentSession:
             return False
         except Exception as e:
             return False
+
+    def log_action(self, action: str, parameters: dict = None):
+        timestamp = datetime.datetime.now().isoformat()
+        self.action_history.append({"action": action, "timestamp": timestamp, "parameters": parameters or {}})
+
+    def get_action_history(self):
+        return self.action_history
 
     def _format_output_line(self, line: str) -> str:
         if not line.strip():


### PR DESCRIPTION
This commit adds agent action history logging to the AgentSession class.  Each action is logged with a timestamp and parameters.  This will allow for better debugging, analysis of agent behavior, and provide crucial context for LLM feedback generation. The `send_message` method has been updated to log the action before sending the message.  The history is stored as a list of dictionaries in the AgentSession class, and methods have been added to append to and retrieve the history.