### PR TITLE
feat: Display repository name in agent view

### DIFF
--- a/static/js/agent_view.js
+++ b/static/js/agent_view.js
@@ -31,7 +31,8 @@ async function fetchUpdates() {
                     'thought': agentData.thought || '',
                     'progress': agentData.progress || '',
                     'future': agentData.future || '',
-                    'action': agentData.last_action || ''
+                    'action': agentData.last_action || '',
+                    'repo-name': agentData.repo_name || ''
                 };
 
                 // Update each field

--- a/templates/agent_view.html
+++ b/templates/agent_view.html
@@ -44,7 +44,7 @@
                 <div class="card-header py-2 d-flex justify-content-between align-items-center" data-bs-toggle="collapse" data-bs-target="#collapse-{{ agent_id }}" style="cursor: pointer;">
                     <div class="d-flex align-items-center">
                         <i class="fas fa-chevron-right me-2 collapse-icon"></i>
-                        <span class="text-muted small me-2">Agent *{{ agent_id[-4:] }}</span>
+                        <span class="text-muted small me-2">Agent <span data-field="agent-id">{{ agent_id[-4:] }}</span> <span class="repo-name" data-field="repo-name"></span></span>
                         <i class="fas fa-tasks me-2"></i>
                         <span class="current-progress text-truncate" data-field="header-progress" style="max-width: 400px;">{{ agent.task }}</span>
                     </div>


### PR DESCRIPTION
This PR adds the repository name to the agent view. The repository name is retrieved from the `agentData` object and displayed prominently in the agent view, enhancing user context and understanding of the agent's operational scope.  Changes were made to `agent_view.js` to handle the display logic and `agent_view.html` to incorporate the repository name into the view.