### PR TITLE
Style Update: Make h1 100% width

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -433,3 +433,9 @@ body {
 .cli-output .user-message {
     color: #007bff; /* OKBLUE */
 }
+
+/* Added rule for h1 */
+h1 {
+    width: 100%;
+    display: block;
+}


### PR DESCRIPTION
This PR adds a CSS rule to make the h1 element occupy 100% of its container's width. The `styles.css` file was updated with the following rule:

```css
h1 {
  width: 100%;
  display: block;
}
```

This ensures that the h1 title will always span the full width, improving layout consistency.