### PR TITLE
feat: Display repository name in agent view

### DIFF
--- a/templates/agent_view.html
+++ b/templates/agent_view.html
@@ -23,7 +23,7 @@
 
     <div class="container mt-5">
         <div class="d-flex justify-content-between align-items-center mb-3">
-            <h4><i class="fas fa-robot me-2"></i>Agent Progress Dashboard</h4>
+            <h4><i class="fas fa-robot me-2"></i>Agent Progress Dashboard - {{ repo_name }}</h4>
             <div>
                 <button id="deleteAllAgents" class="btn btn-sm btn-danger me-2">
                     <i class="fas fa-trash-alt me-1"></i>Delete All Agents


### PR DESCRIPTION
This PR adds the repository name to the agent view. The repository name is extracted from the repository URL passed to the `create_agent` endpoint in `app.py`.  This name is then passed as a template variable to `agent_view.html` and displayed dynamically. Changes were made to both `app.py` and `agent_view.html` to achieve this functionality.