### PR TITLE
Make h1 elements 100% width

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -433,3 +433,8 @@ body {
 .cli-output .user-message {
     color: #007bff; /* OKBLUE */
 }
+
+/* Added rule */
+h1 {
+    width: 100%;
+}


### PR DESCRIPTION
This PR adds a CSS rule to make all h1 elements occupy the full width of their container. The rule `h1 { width: 100%; }` has been added to `styles.css`.