### PR TITLE
Style Update: Full-Width h1

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -433,3 +433,8 @@ body {
 .cli-output .user-message {
     color: #007bff; /* OKBLUE */
 }
+
+/* h1 styles */
+h1 {
+    width: 100%;
+}


### PR DESCRIPTION
This commit adds a new style rule to the `styles.css` file to make the `h1` tag occupy the full viewport width.  The `h1` selector was previously missing from the stylesheet.  This change ensures consistent styling across all viewports.